### PR TITLE
fix: bash should have a status code exit 1 statement upon input check failure

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -65,4 +65,5 @@ runs:
           --exclude-branches "$INPUT_EXCLUDE_BRANCHES"
       else
         echo "Error: please check your inputs"
+        exit 1
       fi


### PR DESCRIPTION
### Summary
bash should have a status code exit 1 statement upon input check failure