### PR TITLE
fix: fix default repo url

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -16,7 +16,7 @@ inputs:
 
   repo-url:
     description: 'Repository URL'
-    default: ${{ github.repository }}
+    default: ${{ github.server_url }}/${{ github.repository }}
     required: true
 
   exclude-branches:


### PR DESCRIPTION
replace default repo url from ${{ github.repository }} to ${{ github.server_url }}/${{ github.repository }}